### PR TITLE
Adicionada opção de produtos que se encaixam

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -460,6 +460,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
                 $this->_postMethodsFixed = $this->_postMethods;
             }
 
+            $itemAltura = $this->_getFitHeight($item);
             $pesoCubicoTotal += (($itemAltura * $itemLargura * $itemComprimento) *
                     $item->getQty()) / $this->getConfigData('coeficiente_volume');
         }
@@ -812,5 +813,34 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
         }
         
         return $this;
+    }
+    
+    /**
+     * Added a fit size for items in large quantities.
+     * Means you can join items like two or more glasses, pots and vases.
+     * The calc is applied only for height side.
+     * Required attribute fit_size. Example:
+     * 
+     *         code: fit_size
+     *         type: varchar
+     * 
+     * After you can set a fit size for all products and improve your sells
+     *
+     * @param Mage_Eav_Model_Entity_Abstract $item Order Item
+     * @return number
+     */
+    protected function _getFitHeight($item)
+    {
+        $product = $item->getProduct();
+        $height = $product->getData('volume_altura');
+        $height = ($height > 0) ? $height : (int) $this->getConfigData('altura_padrao');
+        $fitSize = (float) $product->getData('fit_size');
+        
+        if ($item->getQty() > 1 && is_numeric($fitSize) && $fitSize > 0) {
+            $totalSize = $height + ($fitSize * ($item->getQty() - 1));
+            $height    = $totalSize/$item->getQty();
+        }
+        
+        return $height;
     }
 }

--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -30,6 +30,7 @@
                         <volume_comprimento/>
                         <volume_largura/>
                         <postmethods/>
+                        <fit_size/>
                     </product_attributes>
                 </item>
             </quote>

--- a/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/install-4.4.0.php
+++ b/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/install-4.4.0.php
@@ -75,4 +75,17 @@ $config = array(
 
 $setup->addAttribute('catalog_product', $codigo, $config);
 
+$codigo = 'fit_size';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Diferença do Encaixe (cm)',
+    'type'     => 'varchar',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Caso o produto possa ser encaixado, especifique a diferença de tamanho do encaixe (Exemplo: Um item mede 10cm de altura. Dois itens encaixados medem 11cm. A diferença é de 1cm.)'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
 $installer->endSetup();

--- a/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.3.0-4.4.0.php
+++ b/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.3.0-4.4.0.php
@@ -16,6 +16,9 @@
 $installer = $this;
 $installer->startSetup();
 
+/* @var $installer Mage_Catalog_Model_Resource_Eav_Mysql4_Setup */
+$setup = new Mage_Eav_Model_Entity_Setup('core_setup');
+
 $codigo = 'postmethods';
 $config = array(
     'position' => 1,
@@ -26,6 +29,19 @@ $config = array(
     'source'   => 'pedroteixeira_correios/source_postMethods',
     'apply_to' => 'simple,bundle,grouped,configurable',
     'note'     => 'Selecione os serviços apropriados para o produto.'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$codigo = 'fit_size';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Diferença do Encaixe (cm)',
+    'type'     => 'varchar',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Caso o produto possa ser encaixado, especifique a diferença de tamanho do encaixe (Exemplo: Um item mede 10cm de altura. Dois itens encaixados medem 11cm. A diferença é de 1cm.)'
 );
 
 $setup->addAttribute('catalog_product', $codigo, $config);


### PR DESCRIPTION
Closes pedro-teixeira/correios#46
- Importante: Por padrão o encaixe é associado a altura. Se o produto se encaixa em outra dimensão, considere esta dimensão como a altura.
- O encaixe é aplicado para 2 ou mais unidades de um mesmo item. Itens diferentes, não podem ser encaixados. Porquê? Pois requer um algoritmo mais avançado. Talvez na próxima versão.
