### PR TITLE
Adicionado serviço de Cache para os Correios

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Cache.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Cache.php
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * This source file is subject to the MIT License.
+ * It is also available through http://opensource.org/licenses/MIT
+ *
+ * @category  PedroTeixeira
+ * @package   PedroTeixeira_Correios
+ * @author    Pedro Teixeira <hello@pedroteixeira.io>
+ * @copyright 2014 Pedro Teixeira (http://pedroteixeira.io)
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/pedro-teixeira/correios
+ */
+class PedroTeixeira_Correios_Model_Cache
+    extends Varien_Object
+{
+    /**
+     * Code property
+     *
+     * @var string
+     */
+    protected $_code = 'pedroteixeira_correios';
+    
+    /**
+     * Core cache instance
+     * 
+     * @var Zend_Cache_Core
+     */
+    private $_cache = null;
+    
+    /**
+     * Retrieve cache instance.
+     *
+     * @return Zend_Cache_Core
+     */
+    private function getCache()
+    {
+        if ($this->_cache == null) {
+            $this->_cache = Mage::app()->getCache();
+        }
+        return $this->_cache;
+    }
+
+    /**
+     * Retrieve Zip Tags
+     *
+     * @return array
+     */
+    protected function getZipTags()
+    {
+        $padLength = $this->getConfigData('cache_accuracy/zip');
+        $zipLength = $padLength - 1;
+        $tags = array();
+        $tags[] = "ZIP_".str_pad(substr($this->getData('sCepDestino'), 0, $zipLength--), $padLength, '0');
+        $tags[] = "ZIP_".str_pad(substr($this->getData('sCepDestino'), 0, $zipLength--), $padLength, '0');
+        $tags[] = "ZIP_".str_pad(substr($this->getData('sCepDestino'), 0, $zipLength--), $padLength, '0');
+        $tags[] = "ZIP_".str_pad(substr($this->getData('sCepDestino'), 0, $zipLength--), $padLength, '0');
+        return $tags;
+    }
+    
+    /**
+     * Retrieve Weight Tags
+     *
+     * @return array
+     */
+    protected function getWeightTags()
+    {
+        $tags = array();
+        $tags[] = "WEIGHT_".floor($this->getData('nVlPeso'));
+        $tags[] = "WEIGHT_".ceil($this->getData('nVlPeso'));
+        return $tags;
+    }
+    
+    /**
+     * Retrieve Size Tags
+     *
+     * @return array
+     */
+    protected function getSizeTags()
+    {
+        $tags = array();
+        $type = ($this->getData('nVlAltura') < 40) ? 'REAL' : 'UNDEFINED';
+        $tags[] = "SIZE_{$type}";
+        return $tags;
+    }
+    
+    /**
+     * Retrieve Post Methods Tags
+     * 
+     * @return array
+     */
+    protected function getPostMethodsTags()
+    {
+        $tags = explode(',', $this->getData('nCdServico'));
+        return $tags;
+    }
+
+    /**
+     * When
+     *      ZIP: 51038245
+     *      WEIGHT: 1.3kg
+     *      SIZE: 22cm
+     *
+     * Return example:
+     *   array(
+     *      41068,
+     *      81019,
+     *      ZIP_51038240,
+     *      ZIP_51038200,
+     *      ZIP_51038000,
+     *      WEIGHT_1,
+     *      WEIGHT_2,
+     *      SIZE_REAL,
+     *      PEDROTEIXEIRA_CORREIOS
+     *   )
+     *
+     * @return array
+     */
+    protected function getCacheTags()
+    {
+        $tags = array();
+        $tags = array_merge($tags, $this->getPostMethodsTags());
+        $tags = array_merge($tags, $this->getZipTags());
+        $tags = array_merge($tags, $this->getWeightTags());
+        $tags = array_merge($tags, $this->getSizeTags());
+        $tags[] = 'PEDROTEIXEIRA_CORREIOS';
+        return $tags;
+    }
+
+    /**
+     * Return example:
+     * 		41068x40096x81019_10_16_51030240
+     *
+     * @return string
+     */
+    protected function _getId()
+    {
+        $weight  = round($this->getData('nVlPeso'), $this->getConfigData('cache_accuracy/weight'));
+        $zip     = substr($this->getData('sCepDestino'), 0, $this->getConfigData('cache_accuracy/zip'));
+        $size    = round($this->getData('nVlAltura'), $this->getConfigData('cache_accuracy/size'));
+        $methods = str_replace(',', 'x', $this->getData('nCdServico'));
+        $cacheId = "{$methods}_{$weight}_{$size}_{$zip}";
+        $cacheId = preg_replace("/[^[:alnum:]^_]/", "", $cacheId);
+        return $cacheId;
+    }
+    
+    /**
+     * Retrieve the cache content.
+     *
+     * @return string
+     */
+    public function load()
+    {
+        $data = $this->loadById();
+        if ( !$data ) {
+            $data = $this->loadByTags();
+        }
+        return $data;
+    }
+
+    /**
+     * Retrieve the cache content by key.
+     *
+     * @return string
+     */
+    public function loadById()
+    {
+        $id = $this->_getId();
+        $data = $this->getCache()->load($id);
+        if ( $data ) {
+            Mage::log("{$this->_code} [cache]: mode={$this->getConfigData('cache_mode')} status=hit");
+        }
+        return $data;
+    }
+    
+    /**
+     * Iterates over the ZIP codes, and returns the closest match.
+     *
+     * @return string
+     */
+    public function loadByTags()
+    {
+        $data = false;
+        $padLength = $this->getConfigData('cache_accuracy/zip');
+        for ($i=1; $i<5; $i++) {
+            $zipTag = str_pad(substr($this->getData('sCepDestino'), 0, $padLength-$i), $padLength, '0');
+            $tags = array();
+            $tags = array_merge($tags, $this->getPostMethodsTags());
+            $tags = array_merge($tags, $this->getWeightTags());
+            $tags = array_merge($tags, $this->getSizeTags());
+            $tags[] = 'PEDROTEIXEIRA_CORREIOS';
+            $tags[] = "ZIP_{$zipTag}";
+            $keys = $this->getCache()->getIdsMatchingTags($tags);
+            if (count($keys)) {
+                Mage::log("{$this->_code} [cache]: mode={$this->getConfigData('cache_mode')} status=hit tag=zip value={$zipTag} key={$keys[0]}");
+                $data = $this->getCache()->load($keys[0]);
+                break;
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * Validate the response data from Correios.
+     *
+     * @param string $content XML Content
+     *
+     * @return boolean
+     */
+    protected function _isValidCache($data)
+    {
+        $response = Zend_Http_Response::fromString($data);
+        $content = $response->getBody();
+        $pattern = $this->getConfigData('pattern_nocache');
+        if ($pattern != '' && preg_match($pattern, $content, $matches)) {
+            return false;
+        }
+        if (empty($content)) {
+            return false;
+        }
+        libxml_use_internal_errors(true);
+        $xml = simplexml_load_string($content);
+        if (!$xml || !isset($xml->cServico)) {
+            return false;
+        }
+        return true;
+    }
+    
+    /**
+     * Save Correios content, tags and expiration period.
+     *
+     * @param string $data XML Content
+     *
+     * @return PedroTeixeira_Correios_Model_Cache
+     */
+    public function save($data)
+    {
+        if (!$this->_isValidCache($data)) {
+            throw new Exception('Invalid response');
+        }
+        $id = $this->_getId();
+        $tags = $this->getCacheTags();
+        $timeout = $this->getConfigData('cache_timeout');
+        $this->getCache()->save($data, $id, $tags, $timeout);
+        Mage::log("{$this->_code} [cache]: mode={$this->getConfigData('cache_mode')} status=write key={$id}");
+        return $this;
+    }
+    
+    /**
+     * Retrieve information from carrier configuration
+     *
+     * @param   string $field Field
+     * 
+     * @return  mixed
+     */
+    public function getConfigData($field)
+    {
+        if (empty($this->_code)) {
+            return false;
+        }
+        $path = 'carriers/'.$this->_code.'/'.$field;
+        return Mage::getStoreConfig($path);
+    }
+}

--- a/app/code/community/PedroTeixeira/Correios/Model/Cache.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Cache.php
@@ -192,7 +192,7 @@ class PedroTeixeira_Correios_Model_Cache
             $tags[] = "ZIP_{$zipTag}";
             $keys = $this->getCache()->getIdsMatchingTags($tags);
             if (count($keys)) {
-                Mage::log("{$this->_code} [cache]: mode={$this->getConfigData('cache_mode')} status=hit tag=zip value={$zipTag} key={$keys[0]}");
+                Mage::log("{$this->_code} [cache]: mode={$this->getConfigData('cache_mode')} status=hit tag=zip");
                 $data = $this->getCache()->load($keys[0]);
                 break;
             }
@@ -203,7 +203,7 @@ class PedroTeixeira_Correios_Model_Cache
     /**
      * Validate the response data from Correios.
      *
-     * @param string $content XML Content
+     * @param string $data XML Content
      *
      * @return boolean
      */
@@ -231,6 +231,8 @@ class PedroTeixeira_Correios_Model_Cache
      *
      * @param string $data XML Content
      *
+     * @throws Exception
+     *
      * @return PedroTeixeira_Correios_Model_Cache
      */
     public function save($data)
@@ -249,9 +251,9 @@ class PedroTeixeira_Correios_Model_Cache
     /**
      * Retrieve information from carrier configuration
      *
-     * @param   string $field Field
+     * @param string $field Field
      * 
-     * @return  mixed
+     * @return mixed
      */
     public function getConfigData($field)
     {

--- a/app/code/community/PedroTeixeira/Correios/Model/Cache.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Cache.php
@@ -242,9 +242,9 @@ class PedroTeixeira_Correios_Model_Cache
         }
         $id = $this->_getId();
         $tags = $this->getCacheTags();
-        $timeout = $this->getConfigData('cache_timeout');
-        $this->getCache()->save($data, $id, $tags, $timeout);
-        Mage::log("{$this->_code} [cache]: mode={$this->getConfigData('cache_mode')} status=write key={$id}");
+        if ($this->getCache()->save($data, $id, $tags)) {
+            Mage::log("{$this->_code} [cache]: mode={$this->getConfigData('cache_mode')} status=write key={$id}");
+        }
         return $this;
     }
     

--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -239,7 +239,8 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
             $client = new Zend_Http_Client($filename);
             $client->setConfig(
                 array(
-                    'timeout' => $this->getConfigData('ws_timeout')
+                    'timeout' => $this->getConfigData('ws_timeout'),
+                    'adapter' => $this->getConfigData('cache_adapter')
                 )
             );
 

--- a/app/code/community/PedroTeixeira/Correios/Model/Http/Client/Adapter/Socket.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Http/Client/Adapter/Socket.php
@@ -20,13 +20,19 @@ class PedroTeixeira_Correios_Model_Http_Client_Adapter_Socket
     const CACHE_TYPE = 'pedroteixeira_correios';
     
     /**
-     * (non-PHPdoc)
-     * @see Zend_Http_Client_Adapter_Socket::connect()
+     * Connect to the remote server
+     * 
+     * @param string $host   Host name
+     * @param int    $port   Port number
+     * @param bool   $secure Secure flag
+     * 
+     * @return void
      */
     public function connect($host, $port=80, $secure=false)
     {
         if (Mage::app()->useCache(self::CACHE_TYPE)) {
-            if (!($this->getConfigData('cache_mode') == PedroTeixeira_Correios_Model_Source_CacheMode::MODE_CACHE_ONLY)) {
+            $mode = $this->getConfigData('cache_mode');
+            if (!($mode == PedroTeixeira_Correios_Model_Source_CacheMode::MODE_CACHE_ONLY)) {
                 try {
                     parent::connect($host, $port, $secure);
                 } catch (Zend_Http_Client_Adapter_Exception $e) {
@@ -39,8 +45,15 @@ class PedroTeixeira_Correios_Model_Http_Client_Adapter_Socket
     }
     
     /**
-     * (non-PHPdoc)
-     * @see Zend_Http_Client_Adapter_Socket::write()
+     * Send request to the remote server
+     *
+     * @param string        $method   Method
+     * @param Zend_Uri_Http $uri      Uri
+     * @param string        $http_ver HTTP version
+     * @param array         $headers  Headers
+     * @param string        $body     Body
+     * 
+     * @return string Request as string
      */
     public function write($method, $uri, $http_ver = '1.1', $headers = array(), $body = '')
     {
@@ -59,8 +72,11 @@ class PedroTeixeira_Correios_Model_Http_Client_Adapter_Socket
     }
 
     /**
-     * (non-PHPdoc)
+     * Read response from server
+     * 
      * @see Zend_Http_Client_Adapter_Socket::read()
+     * 
+     * @return string
      */
     public function read()
     {
@@ -111,9 +127,9 @@ class PedroTeixeira_Correios_Model_Http_Client_Adapter_Socket
     /**
      * Retrieve information from carrier configuration
      *
-     * @param   string $field Field
+     * @param string $field Field
      *
-     * @return  mixed
+     * @return mixed
      */
     public function getConfigData($field)
     {

--- a/app/code/community/PedroTeixeira/Correios/Model/Http/Client/Adapter/Socket.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Http/Client/Adapter/Socket.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * This source file is subject to the MIT License.
+ * It is also available through http://opensource.org/licenses/MIT
+ *
+ * @category  PedroTeixeira
+ * @package   PedroTeixeira_Correios
+ * @author    Pedro Teixeira <hello@pedroteixeira.io>
+ * @copyright 2014 Pedro Teixeira (http://pedroteixeira.io)
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/pedro-teixeira/correios
+ */
+class PedroTeixeira_Correios_Model_Http_Client_Adapter_Socket
+    extends Zend_Http_Client_Adapter_Socket
+{
+    protected $_cache = null;
+    protected $_params = null;
+    protected $_code = 'pedroteixeira_correios';
+    const CACHE_TYPE = 'pedroteixeira_correios';
+    
+    /**
+     * (non-PHPdoc)
+     * @see Zend_Http_Client_Adapter_Socket::connect()
+     */
+    public function connect($host, $port=80, $secure=false)
+    {
+        if (Mage::app()->useCache(self::CACHE_TYPE)) {
+            if (!($this->getConfigData('cache_mode') == PedroTeixeira_Correios_Model_Source_CacheMode::MODE_CACHE_ONLY)) {
+                try {
+                    parent::connect($host, $port, $secure);
+                } catch (Zend_Http_Client_Adapter_Exception $e) {
+                    Mage::log("{$this->_code} [socket]: {$e->getMessage()}");
+                }
+            }
+        } else {
+            parent::connect($host, $port, $secure);
+        }
+    }
+    
+    /**
+     * (non-PHPdoc)
+     * @see Zend_Http_Client_Adapter_Socket::write()
+     */
+    public function write($method, $uri, $http_ver = '1.1', $headers = array(), $body = '')
+    {
+        $request = false;
+        if (Mage::app()->useCache(self::CACHE_TYPE)) {
+            $this->_params = $uri->getQueryAsArray();
+            try {
+                $request = parent::write($method, $uri, $http_ver, $headers, $body);
+            } catch (Zend_Http_Client_Adapter_Exception $e) {
+                Mage::log("{$this->_code} [socket]: {$e->getMessage()}");
+            }
+        } else {
+            $request = parent::write($method, $uri, $http_ver, $headers, $body);
+        }
+        return $request;
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Zend_Http_Client_Adapter_Socket::read()
+     */
+    public function read()
+    {
+        $response = false;
+        if (Mage::app()->useCache(self::CACHE_TYPE)) {
+            $cache = $this->getCache();
+            $cache->addData($this->_params);
+            $cacheMode = $this->getConfigData('cache_mode');
+            if ($cacheMode == PedroTeixeira_Correios_Model_Source_CacheMode::MODE_HTTP_PRIOR) {
+                try {
+                    $response = parent::read();
+                    $cache->save($response);
+                } catch (Zend_Http_Client_Adapter_Exception $e) {
+                    $response = $cache->load();
+                }
+            } elseif ($cacheMode == PedroTeixeira_Correios_Model_Source_CacheMode::MODE_CACHE_PRIOR) {
+                $response = $cache->loadById();
+                if (!$response) {
+                    try {
+                        $response = parent::read();
+                        $cache->save($response);
+                    } catch (Zend_Http_Client_Adapter_Exception $e) {
+                        $response = $cache->loadByTags();
+                    }
+                }
+            } elseif ($cacheMode == PedroTeixeira_Correios_Model_Source_CacheMode::MODE_CACHE_ONLY) {
+                $response = $cache->load();
+            }
+        } else {
+            $response = parent::read();
+        }
+        return $response;
+    }
+    
+    /**
+     * Retrieves the cache instance
+     *
+     * @return PedroTeixeira_Correios_Model_Cache
+     */
+    public function getCache()
+    {
+        if ($this->_cache == null) {
+            $this->_cache = Mage::getModel('pedroteixeira_correios/cache');
+        }
+        return $this->_cache;
+    }
+
+    /**
+     * Retrieve information from carrier configuration
+     *
+     * @param   string $field Field
+     *
+     * @return  mixed
+     */
+    public function getConfigData($field)
+    {
+        if (empty($this->_code)) {
+            return false;
+        }
+        $path = 'carriers/'.$this->_code.'/'.$field;
+        return Mage::getStoreConfig($path);
+    }
+}

--- a/app/code/community/PedroTeixeira/Correios/Model/Source/CacheMode.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Source/CacheMode.php
@@ -25,9 +25,9 @@ class PedroTeixeira_Correios_Model_Source_CacheMode extends Mage_Eav_Model_Entit
     public function toOptionArray()
     {
         return array(
-            array('value' => self::MODE_HTTP_PRIOR, 'label' => Mage::helper('adminhtml')->__('Consultar os Correios; e, se falhar, o Cache')),
-            array('value' => self::MODE_CACHE_PRIOR, 'label' => Mage::helper('adminhtml')->__('Consultar o Cache; e, se falhar, os Correios')),
-            array('value' => self::MODE_CACHE_ONLY, 'label' => Mage::helper('adminhtml')->__('Consultar somente o Cache')),
+            array('value' => self::MODE_HTTP_PRIOR, 'label' => 'Consultar os Correios; e, se falhar, o Cache'),
+            array('value' => self::MODE_CACHE_PRIOR, 'label' => 'Consultar o Cache; e, se falhar, os Correios'),
+            array('value' => self::MODE_CACHE_ONLY, 'label' => 'Consultar somente o Cache'),
         );
     }
 

--- a/app/code/community/PedroTeixeira/Correios/Model/Source/CacheMode.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Source/CacheMode.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This source file is subject to the MIT License.
+ * It is also available through http://opensource.org/licenses/MIT
+ *
+ * @category  PedroTeixeira
+ * @package   PedroTeixeira_Correios
+ * @author    Pedro Teixeira <hello@pedroteixeira.io>
+ * @copyright 2014 Pedro Teixeira (http://pedroteixeira.io)
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/pedro-teixeira/correios
+ */
+class PedroTeixeira_Correios_Model_Source_CacheMode extends Mage_Eav_Model_Entity_Attribute_Source_Abstract
+{
+    const MODE_HTTP_PRIOR = 0;
+    const MODE_CACHE_PRIOR = 1;
+    const MODE_CACHE_ONLY = 2;
+    
+    /**
+     * Get options for methods
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return array(
+            array('value' => self::MODE_HTTP_PRIOR, 'label' => Mage::helper('adminhtml')->__('Consultar os Correios; e, se falhar, o Cache')),
+            array('value' => self::MODE_CACHE_PRIOR, 'label' => Mage::helper('adminhtml')->__('Consultar o Cache; e, se falhar, os Correios')),
+            array('value' => self::MODE_CACHE_ONLY, 'label' => Mage::helper('adminhtml')->__('Consultar somente o Cache')),
+        );
+    }
+
+    /**
+     * Get options for input fields
+     * 
+     * @see Mage_Eav_Model_Entity_Attribute_Source_Interface::getAllOptions()
+     * 
+     * @return array
+     */
+    public function getAllOptions()
+    {
+        return self::toOptionArray();
+    }
+}

--- a/app/code/community/PedroTeixeira/Correios/Model/Source/PostMethods.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Source/PostMethods.php
@@ -23,6 +23,7 @@ class PedroTeixeira_Correios_Model_Source_PostMethods extends Mage_Eav_Model_Ent
         return array(
             array('value' => 40010, 'label' => Mage::helper('adminhtml')->__('Sedex Sem Contrato (40010)')),
             array('value' => 40096, 'label' => Mage::helper('adminhtml')->__('Sedex Com Contrato (40096)')),
+            array('value' => 40436, 'label' => Mage::helper('adminhtml')->__('Sedex Com Contrato (40436)')),
             array('value' => 81019, 'label' => Mage::helper('adminhtml')->__('E-Sedex Com Contrato (81019)')),
             array('value' => 41106, 'label' => Mage::helper('adminhtml')->__('PAC Sem Contrato (41106)')),
             array('value' => 41068, 'label' => Mage::helper('adminhtml')->__('PAC Com Contrato (41068)')),

--- a/app/code/community/PedroTeixeira/Correios/Model/Source/PostMethods.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Source/PostMethods.php
@@ -23,7 +23,6 @@ class PedroTeixeira_Correios_Model_Source_PostMethods extends Mage_Eav_Model_Ent
         return array(
             array('value' => 40010, 'label' => Mage::helper('adminhtml')->__('Sedex Sem Contrato (40010)')),
             array('value' => 40096, 'label' => Mage::helper('adminhtml')->__('Sedex Com Contrato (40096)')),
-            array('value' => 40436, 'label' => Mage::helper('adminhtml')->__('Sedex Com Contrato (40436)')),
             array('value' => 81019, 'label' => Mage::helper('adminhtml')->__('E-Sedex Com Contrato (81019)')),
             array('value' => 41106, 'label' => Mage::helper('adminhtml')->__('PAC Sem Contrato (41106)')),
             array('value' => 41068, 'label' => Mage::helper('adminhtml')->__('PAC Com Contrato (41068)')),

--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <PedroTeixeira_Correios>
-            <version>4.2.0</version>
+            <version>4.4.0</version>
             <depends>
                 <Mage_Shipping/>
             </depends>
@@ -64,6 +64,15 @@
                 </carriers>
             </shipping>
         </sales>
+        <cache>
+        	<types>
+        		<pedroteixeira_correios translate="label,description" module="pedroteixeira_correios">
+        			<label>Correios Cache</label>
+        			<description>Banco de Cotações dos Correios.</description>
+        			<tags>PEDROTEIXEIRA_CORREIOS</tags>
+        		</pedroteixeira_correios>
+        	</types>
+        </cache>
     </global>
 
     <default>
@@ -81,7 +90,7 @@
                 <max_order_value>10000</max_order_value>
                 <maxweight>30</maxweight>
                 <handling_fee>0</handling_fee>
-                <ws_timeout>20</ws_timeout>
+                <ws_timeout>10</ws_timeout>
 
                 <!-- OPTIONS -->
                 <mao_propria>0</mao_propria>
@@ -122,6 +131,13 @@
                             <weight>30</weight>
                         </max>
                     </serv_40096>
+                    <serv_40436>
+                        <max>
+                            <size>105</size>
+                            <sum>200</sum>
+                            <weight>30</weight>
+                        </max>
+                    </serv_40436>
                     <serv_81019>
                         <max>
                             <size>105</size>
@@ -208,6 +224,7 @@
                 <!-- SYSTEM -->
                 <serv_40010>Sedex,3</serv_40010>
                 <serv_40096>Sedex,3</serv_40096>
+                <serv_40436>Sedex,3</serv_40436>
                 <serv_81019>E-Sedex,3</serv_81019>
                 <serv_41106>PAC,3</serv_41106>
                 <serv_41068>PAC,3</serv_41068>
@@ -220,8 +237,19 @@
                 <volume_weight_min>5</volume_weight_min>
                 <coeficiente_volume>6000</coeficiente_volume>
                 <acobrar_code>40045</acobrar_code>
-                <contrato_codes>40096,81019,41068,41300</contrato_codes>
+                <contrato_codes>40096,81019,41068,41300,40436</contrato_codes>
                 <url_ws_correios>http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx</url_ws_correios>
+
+                <!-- CACHE -->
+                <pattern_nocache><![CDATA[/<Erro>(-2|-3|-5|-6|-7|-8|-9|-10|-11|-12|-13|-14|-15|-16|-17|-18|-20|-22|-23|-24|-25|-26|-27|-28|-29|-30|-31|-32|-33|-34|-35|-36|-37|-38|-39|-40|-41|-42|-43|-44|-45|-888|006|007|009|010|011|7|99)<\/Erro>/]]></pattern_nocache>
+                <cache_timeout>31536000</cache_timeout>
+                <cache_accuracy>
+                    <weight>1</weight>
+                    <zip>8</zip>
+                    <size>0</size>
+                </cache_accuracy>
+                <cache_mode>0</cache_mode>
+                <cache_adapter>PedroTeixeira_Correios_Model_Http_Client_Adapter_Socket</cache_adapter>
 
                 <!-- ADDITIONAL POST METHODS -->
                 <add_method_0>

--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <PedroTeixeira_Correios>
-            <version>4.4.0</version>
+            <version>4.2.0</version>
             <depends>
                 <Mage_Shipping/>
             </depends>
@@ -90,7 +90,7 @@
                 <max_order_value>10000</max_order_value>
                 <maxweight>30</maxweight>
                 <handling_fee>0</handling_fee>
-                <ws_timeout>10</ws_timeout>
+                <ws_timeout>20</ws_timeout>
 
                 <!-- OPTIONS -->
                 <mao_propria>0</mao_propria>
@@ -131,13 +131,6 @@
                             <weight>30</weight>
                         </max>
                     </serv_40096>
-                    <serv_40436>
-                        <max>
-                            <size>105</size>
-                            <sum>200</sum>
-                            <weight>30</weight>
-                        </max>
-                    </serv_40436>
                     <serv_81019>
                         <max>
                             <size>105</size>
@@ -224,7 +217,6 @@
                 <!-- SYSTEM -->
                 <serv_40010>Sedex,3</serv_40010>
                 <serv_40096>Sedex,3</serv_40096>
-                <serv_40436>Sedex,3</serv_40436>
                 <serv_81019>E-Sedex,3</serv_81019>
                 <serv_41106>PAC,3</serv_41106>
                 <serv_41068>PAC,3</serv_41068>
@@ -237,7 +229,7 @@
                 <volume_weight_min>5</volume_weight_min>
                 <coeficiente_volume>6000</coeficiente_volume>
                 <acobrar_code>40045</acobrar_code>
-                <contrato_codes>40096,81019,41068,41300,40436</contrato_codes>
+                <contrato_codes>40096,81019,41068,41300</contrato_codes>
                 <url_ws_correios>http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx</url_ws_correios>
 
                 <!-- CACHE -->

--- a/app/code/community/PedroTeixeira/Correios/etc/system.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/system.xml
@@ -330,6 +330,16 @@
                             <show_in_store>1</show_in_store>
                             <comment>A cotação irá exibir somente os serviços de postagem comuns a todos os produtos do carrinho de compras.</comment>
                         </filter_by_item>
+                        <cache_mode translate="label">
+                            <label>Modo de Prioridade da Cache</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>PedroTeixeira_Correios_Model_Source_CacheMode</source_model>
+                            <sort_order>267</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Esta configuração se aplica somente quando Correios Cache estiver ativo, em Sistema > Gerenciar Cache.</comment>
+                        </cache_mode>
                         <sort_order translate="label">
                             <label>Ordenar Por</label>
                             <frontend_type>text</frontend_type>


### PR DESCRIPTION
Adicionada opção de cache para as cotações de frete dos Correios.
A cache é administrada pelo gerenciador de cache do Magento, em __Sistema > Gerenciar Cache__.
Nas configurações da extensão, é possível escolher entre 3 modos de operação:

* Consultar os Correios; e, se falhar, o Cache (recomendado)
* Consultar o Cache; e, se falhar, os Correios
* Consultar somente o Cache

O sistema de cache do Magento pode ser configurado para utilizar diferentes sistemas de cache, entre Files, Memcached, APC, Redis, etc (ver arquivo __/app/etc/local.xml__).
Entretanto foi adicionado um algoritmo de aproximação do CEP, para sistemas que aceitam o uso de Tags, como o Redis. Neste caso, o cache de CEP mais próximo é selecionado, caso os Correios estejam offline.