### PR TITLE
Adicionada opção de dividir a entrega em mais de um pacote.

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -202,6 +202,7 @@
                 <add_prazo>0</add_prazo>
                 <showmethod>1</showmethod>
                 <filter_by_item>0</filter_by_item>
+                <split_pack>1</split_pack>
 
                 <!-- MESSAGES -->
                 <msgprazo>%s - Em média %d dia(s)</msgprazo>

--- a/app/code/community/PedroTeixeira/Correios/etc/system.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/system.xml
@@ -340,6 +340,16 @@
                             <show_in_store>1</show_in_store>
                             <comment>Esta configuração se aplica somente quando Correios Cache estiver ativo, em Sistema > Gerenciar Cache.</comment>
                         </cache_mode>
+                        <split_pack translate="label">
+                            <label>Habilitar Divisão de Pacotes</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>268</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>O pacote é dividido, caso o carrinho exceda os limites de peso e tamanho, para todos os serviços. A divisão se repete até que os limites sejam válidos, para um ou mais serviços.</comment>
+                        </split_pack>
                         <sort_order translate="label">
                             <label>Ordenar Por</label>
                             <frontend_type>text</frontend_type>


### PR DESCRIPTION
Adicionada opção de dividir o carrinho de compras, caso exceda os limites de tamanho e peso, para todos os serviços de entrega.
O pacote é dividido até que esteja válido para cotação em pelo menos um método de entrega.
A cotação é realizada, e o valor é multiplicado pelo número de divisões.