### PR TITLE
Adicionada opção de incluir Prazo de Postagem no produto

### DIFF
--- a/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
+++ b/app/code/community/PedroTeixeira/Correios/Model/Carrier/CorreiosMethod.php
@@ -44,6 +44,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
     protected $_freeMethodWeight = null;
     protected $_midSize = null;
     protected $_splitUp = 0;
+    protected $_postingDays = 0;
 
     /**
      * Post methods
@@ -346,7 +347,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
                     sprintf(
                         $this->getConfigData('msgprazo'),
                         $shippingData[0],
-                        (int) ($correiosDelivery + $this->getConfigData('add_prazo'))
+                        (int) ($correiosDelivery + $this->getConfigData('add_prazo') + $this->_postingDays)
                     )
                 );
             } else {
@@ -354,7 +355,7 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
                     sprintf(
                         $this->getConfigData('msgprazo'),
                         $shippingData[0],
-                        (int) ($shippingData[1] + $this->getConfigData('add_prazo'))
+                        (int) ($shippingData[1] + $this->getConfigData('add_prazo') + $this->_postingDays)
                     )
                 );
             }
@@ -461,6 +462,8 @@ class PedroTeixeira_Correios_Model_Carrier_CorreiosMethod
             $itemAltura = $this->_getFitHeight($item);
             $pesoCubicoTotal += (($itemAltura * $itemLargura * $itemComprimento) *
                     $item->getQty()) / $this->getConfigData('coeficiente_volume');
+
+            $this->_postingDays = max($this->_postingDays, (int) $_product->getData('posting_days'));
         }
 
         $this->_volumeWeight = number_format($pesoCubicoTotal, 2, '.', '');

--- a/app/code/community/PedroTeixeira/Correios/etc/config.xml
+++ b/app/code/community/PedroTeixeira/Correios/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <PedroTeixeira_Correios>
-            <version>4.4.0</version>
+            <version>4.4.1</version>
             <depends>
                 <Mage_Shipping/>
             </depends>
@@ -31,6 +31,7 @@
                         <volume_largura/>
                         <postmethods/>
                         <fit_size/>
+                        <posting_days/>
                     </product_attributes>
                 </item>
             </quote>

--- a/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/install-4.4.1.php
+++ b/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/install-4.4.1.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This source file is subject to the MIT License.
+ * It is also available through http://opensource.org/licenses/MIT
+ *
+ * @category  PedroTeixeira
+ * @package   PedroTeixeira_Correios
+ * @author    Pedro Teixeira <hello@pedroteixeira.io>
+ * @copyright 2015 Pedro Teixeira (http://pedroteixeira.io)
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/pedro-teixeira/correios
+ */
+
+/** @var $installer Mage_Core_Model_Resource_Setup */
+$installer = $this;
+$installer->startSetup();
+
+/* @var $installer Mage_Catalog_Model_Resource_Eav_Mysql4_Setup */
+$setup = new Mage_Eav_Model_Entity_Setup('core_setup');
+
+// Add volume to prduct attribute set
+$codigo = 'volume_comprimento';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Comprimento (cm)',
+    'type'     => 'int',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Comprimento da embalagem do produto (Para cálculo dos Correios)'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+// Add volume to prduct attribute set
+$codigo = 'volume_altura';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Altura (cm)',
+    'type'     => 'int',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Altura da embalagem do produto (Para cálculo dos Correios)'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+// Add volume to prduct attribute set
+$codigo = 'volume_largura';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Largura (cm)',
+    'type'     => 'int',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Largura da embalagem do produto (Para cálculo dos Correios)'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$codigo = 'postmethods';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Serviços de Entrega',
+    'type'     => 'text',
+    'input'    => 'multiselect',
+    'source'   => 'pedroteixeira_correios/source_postMethods',
+    'backend'  => 'eav/entity_attribute_backend_array',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Selecione os serviços apropriados para o produto.'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$codigo = 'fit_size';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Diferença do Encaixe (cm)',
+    'type'     => 'varchar',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'Exemplo: Se 1 item mede 10cm de altura, e 2 itens encaixados medem 11cm. A diferença é de 1cm.'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$codigo = 'posting_days';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Prazo de Postagem',
+    'type'     => 'int',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'O prazo total é o Prazo dos Correios acrescido do maior Prazo de Postagem dos produtos no carrinho.'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$installer->endSetup();

--- a/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.4.0-4.4.1.php
+++ b/app/code/community/PedroTeixeira/Correios/sql/pedroteixeira_correios_setup/upgrade-4.4.0-4.4.1.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This source file is subject to the MIT License.
+ * It is also available through http://opensource.org/licenses/MIT
+ *
+ * @category  PedroTeixeira
+ * @package   PedroTeixeira_Correios
+ * @author    Pedro Teixeira <hello@pedroteixeira.io>
+ * @copyright 2015 Pedro Teixeira (http://pedroteixeira.io)
+ * @license   http://opensource.org/licenses/MIT MIT
+ * @link      https://github.com/pedro-teixeira/correios
+ */
+
+/** @var $installer Mage_Core_Model_Resource_Setup */
+$installer = $this;
+$installer->startSetup();
+
+/* @var $installer Mage_Catalog_Model_Resource_Eav_Mysql4_Setup */
+$setup = new Mage_Eav_Model_Entity_Setup('core_setup');
+
+$codigo = 'posting_days';
+$config = array(
+    'position' => 1,
+    'required' => 0,
+    'label'    => 'Prazo de Postagem',
+    'type'     => 'int',
+    'input'    => 'text',
+    'apply_to' => 'simple,bundle,grouped,configurable',
+    'note'     => 'O prazo total é o Prazo dos Correios acrescido do maior Prazo de Postagem dos produtos no carrinho.'
+);
+
+$setup->addAttribute('catalog_product', $codigo, $config);
+
+$installer->endSetup();


### PR DESCRIPTION
O prazo exibido para o cliente será o prazo da cotação dos Correios, acrescido do prazo adicional nas configurações da extensão, acrescido do maior prazo de postagem dentre os produtos, no carrinho de compras.

`prazo da cotação + prazo adicional + prazo maior do carrinho`